### PR TITLE
Support running a callback when a job is submitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,8 @@ module.exports = function gearman(host='127.0.0.1', port=4730, options={}) {
 
   // submit a job to the gearman server
   // @param options supported options are: id, bg, payload
-  const submitJob = function(func_name, data=null, options={}) {
+  // @param callback Function to call after the job has been submitted
+  const submitJob = function(func_name, data=null, options={}, callback=null) {
     if (typeof(func_name) !== 'string')
       throw new Error('function name must be a string')
 
@@ -169,7 +170,7 @@ module.exports = function gearman(host='127.0.0.1', port=4730, options={}) {
       buffer()
 
     let job = _encodePacket(packet_type, payload, options.encoding)
-    _send(job, options.encoding)
+    _send(job, options.encoding, callback)
   }
 
   // public gearman worker functions
@@ -578,10 +579,10 @@ module.exports = function gearman(host='127.0.0.1', port=4730, options={}) {
   }
 
   // common socket I/O
-  const _send = function (data, encoding=null) {
+  const _send = function (data, encoding=null, callback=null) {
     if (!_connected)
       throw new Error('Cannot send packets before connecting. Please connect first.')
-    _conn.write(data, encoding)
+    _conn.write(data, encoding, callback)
   }
 
   // common send function. send a packet with 1 string


### PR DESCRIPTION
## Description
This PR adds support for running a callback after a job is completely submitted. The callback supported by the nodejs net.socket is exposed here, so that the client can know when the job submission is complete. Since socket.write may buffer in internal memory, the callback is the most reliable way to know that all the data has been transmitted.

This use case here is a one-off script that creates a gearman client, and schedules a job but doesn't need to wait for the job to be completed. In our case we're using an AWS lambda to schedule gearman jobs. We don't want the script running until the job is complete so we use as little billable time as possible, but we do need to guarantee that the packets have been sent.