### PR TITLE
added KeepAlive to socket-options

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ module.exports = function gearman(host='127.0.0.1', port=4730, options={}) {
   if (options && options.timeout != null) {
     _conn.setTimeout(options.timeout)
   }
+  
+  if (options && options.KeepAlive != null) {
+    _conn.setKeepAlive(options.KeepAlive)
+  }
 
   _conn.on('data', function (chunk) {
     // add the stream of incoming bytes to the packet factory


### PR DESCRIPTION
In some circumstances the socket throws an unhandled ECONNRESET, because something between Server & Client terminates the TCP-Connections.
This options allows to do a TCP-Keepalive, so this wont happen anymore.

Please add this to the master